### PR TITLE
Ignore NetBeans project properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ release.properties
 # Gradle
 .gradle/
 build/
+nbproject/project.properties


### PR DESCRIPTION
Added nbproject/project.properties to .gitignore to prevent committing NetBeans-specific project configuration files.